### PR TITLE
move project flag into get_clusters

### DIFF
--- a/cmd/get_clusters.go
+++ b/cmd/get_clusters.go
@@ -61,7 +61,6 @@ var getClustersCmd = &cobra.Command{
 func init() {
 	getCmd.AddCommand(getClustersCmd)
 
-	AddProjectFlag(getClustersCmd)
-
-	getClustersCmd.Flags().BoolVarP(&listAll, "all", "a", false, "To list all clusters in all projects if the users is allowed to see.")
+	getClustersCmd.Flags().StringVarP(&projectID, "project", "p", "", "ID of the project.")
+	getClustersCmd.RegisterFlagCompletionFunc("project", completion.GetValidProjectArgs)
 }


### PR DESCRIPTION
removed the --all feature as it is the default
add the --project as not required, as withput we get all